### PR TITLE
openai 1.25.0

### DIFF
--- a/recipe/001-remove-fancy-pypi-readme.patch
+++ b/recipe/001-remove-fancy-pypi-readme.patch
@@ -1,0 +1,43 @@
+From edbf81500178eb815a87d9812d59b09032732e5f Mon Sep 17 00:00:00 2001
+From: Serhii Kupriienko
+Date: Thu, 2 May 2024 18:04:29 +0300
+Subject: [PATCH] Remove fancy-pypi-readme
+
+---
+ pyproject.toml | 13 +------------
+ 1 file changed, 1 insertion(+), 12 deletions(-)
+
+diff --git a/pyproject.toml b/pyproject.toml
+index ffc98fd..87f54fe 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -94,7 +94,7 @@ typecheck = { chain = [
+ "typecheck:mypy" = "mypy ."
+ 
+ [build-system]
+-requires = ["hatchling", "hatch-fancy-pypi-readme"]
++requires = ["hatchling"]
+ build-backend = "hatchling.build"
+ 
+ [tool.hatch.build]
+@@ -105,17 +105,6 @@ include = [
+ [tool.hatch.build.targets.wheel]
+ packages = ["src/openai"]
+ 
+-[tool.hatch.metadata.hooks.fancy-pypi-readme]
+-content-type = "text/markdown"
+-
+-[[tool.hatch.metadata.hooks.fancy-pypi-readme.fragments]]
+-path = "README.md"
+-
+-[[tool.hatch.metadata.hooks.fancy-pypi-readme.substitutions]]
+-# replace relative links with absolute links
+-pattern = '\[(.+?)\]\(((?!https?://)\S+?)\)'
+-replacement = '[\1](https://github.com/openai/openai-python/tree/main/\g<2>)'
+-
+ [tool.black]
+ line-length = 120
+ target-version = ["py37"]
+-- 
+2.44.0
+

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -65,8 +65,8 @@ about:
     This library additionally provides an `openai` command-line utility which
     makes it easy to interact with the API from your terminal.
     Run `openai api -h` for usage.
-  license: MIT
-  license_family: MIT
+  license: Apache-2.0
+  license_family: Apache
   license_file: LICENSE
   doc_url: https://github.com/openai/openai-python
   dev_url: https://github.com/openai/openai-python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,6 +37,7 @@ requirements:
     - tqdm >4
     - typing-extensions <5,>=4.7
     - cached-property  # [py<38]
+  run_constrained:
     # The following are required for the optional things.
     - numpy >=1
     - pandas >=1.2.3

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,13 +1,15 @@
 {% set name = "openai" %}
-{% set version = "1.9.0" %}
+{% set version = "1.25.0" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://github.com/openai/openai-python/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: 48a8118a555a8d4c7e780f41c3abeecf17bbba09b1a5ae0dbc29eae3111ecb0c
+  url: https://github.com/{{ name }}/{{ name }}-python/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: 3cd5b10399eb97e498f97a7bf88ffbd101fa44fb35bfe7c4885f87c1c672f892
+  patches:
+    - 001-remove-fancy-pypi-readme.patch
 
 build:
   number: 0
@@ -18,6 +20,9 @@ build:
   skip: True # [py<37 or s390x]
 
 requirements:
+  build:
+    - patch     # [not win]
+    - m2-patch  # [win]
   host:
     - python
     - pip


### PR DESCRIPTION
**Destination channel:** main

### Links

- [PKG-4502](https://anaconda.atlassian.net/browse/PKG-4502) 
- [Upstream repository](https://github.com/openai/openai-python/tree/v1.25.0)
- Requirements: https://github.com/openai/openai-python/blob/v1.25.0/pyproject.toml

### Explanation of changes:

- Add patch for removing fancy-pypi-readme dependency


[PKG-4502]: https://anaconda.atlassian.net/browse/PKG-4502?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ